### PR TITLE
Added ThresholdType enum integer values

### DIFF
--- a/source/opencvd/imgproc.d
+++ b/source/opencvd/imgproc.d
@@ -514,14 +514,14 @@ void houghLinesPointSet(Mat points, Mat lines, int lines_max, int threshold,
 }
 
 enum: int {
-    THRESH_BINARY,
-    THRESH_BINARY_INV,
-    THRESH_TRUNC,
-    THRESH_TOZERO,
-    THRESH_TOZERO_INV,
-    THRESH_MASK,
-    THRESH_OTSU,
-    THRESH_TRIANGLE
+  THRESH_BINARY = 0,
+  THRESH_BINARY_INV = 1,
+  THRESH_TRUNC = 2,
+  THRESH_TOZERO = 3,
+  THRESH_TOZERO_INV = 4,
+  THRESH_MASK = 7,
+  THRESH_OTSU = 8,
+  THRESH_TRIANGLE = 16
 }
   
 enum: int {


### PR DESCRIPTION
Simply added the integer values to the ThresholdType enum to allow for combinations e.g: 'THRESH_BINARY | THRESH_OTSU'.
Integer values taken from: https://docs.opencv.org/3.4/d7/d1b/group__imgproc__misc.html

A simple example (so small not worth including) would be:
```
import std.stdio;
import std.format;
import std.random;
import std.math;

import opencvd;

//(https://stackoverflow.com/questions/17141535/how-to-use-the-otsu-threshold-in-opencv) (http://archive.is/AYMuX)

static void testThreshold(Mat src)
{
    // Show source image
    imshow("src", src);
    // Transform source image to gray if it is not
    Mat gray;
    if (src.channels() == 3)
    {
        cvtColor(src, gray, COLOR_BGR2GRAY);
    }
    else
    {
        gray = src;
    }
    // Show gray image
    imshow("gray", gray);
    //Mat im_gray = imread("img3.jpg",CV_LOAD_IMAGE_GRAYSCALE);
    Mat bw = Mat();
    threshold(gray, bw, 128, 255, THRESH_BINARY | THRESH_OTSU);
    imshow("Binary | OTSU",bw);
    Mat bw2 = Mat();
    threshold(gray, bw2, 128, 255, THRESH_BINARY + THRESH_OTSU);
    imshow("Binary + OTSU",bw2);
    Mat bw3 = Mat();
    adaptiveThreshold(gray, bw3, 255, ADAPTIVE_THRESH_GAUSSIAN_C,THRESH_BINARY,11,2);
    imshow("Adaptive Gaussian Binary",bw3);
}

int main( )
{
    Mat image = imread("morphlines.png", IMREAD_GRAYSCALE);
    if(image.empty())
    {
        "Cannot read image file: ".writeln;
        return -1;
    }
    
    testThreshold(image);
    waitKey(0);
    return 0;
} 
```

Without these values these calls fail:
    threshold(gray, bw, 128, 255, THRESH_BINARY | THRESH_OTSU);
OR
    threshold(gray, bw, 128, 255, THRESH_BINARY + THRESH_OTSU);